### PR TITLE
Fix for Server returned HTTP response code: 400

### DIFF
--- a/BunnyCDN/src/bunnycdn/BCDNStorage.java
+++ b/BunnyCDN/src/bunnycdn/BCDNStorage.java
@@ -96,6 +96,7 @@ public class BCDNStorage extends Exception {
         String inputLine;
         BufferedReader in;
         StringBuffer resp = new StringBuffer();
+        url = java.net.URLEncoder.encode(url, "UTF-8").replace("+", "%20");
         HttpsURLConnection req = (HttpsURLConnection) (new URL(BASE_URL + "/" + nameOfZone + "/" + url)).openConnection();
         req.setRequestMethod(method);
         // For analytical purposes


### PR DESCRIPTION
Related to https://github.com/BunnyWay/BunnyCDN.Java.Storage/issues/4
This pull fix for download that having HTTP Response code 400 because of no url parsing so i added it and it fixes the problem